### PR TITLE
chore: change query option token to accessToken

### DIFF
--- a/examples/player.html
+++ b/examples/player.html
@@ -167,7 +167,7 @@
                     const host = options.host;
                     this.host = new NetAddress(host || location.host, 443);
                     this.streamName = options.stream;
-                    this.accessToken = options.token;
+                    this.accessToken = options.accessToken;
                     this.connectorType = options.whep || (host && host.toLowerCase().startsWith('http')) ? this.connectorTypes[1] : this.connectorTypes[0];
                 },
                 methods: {

--- a/examples/streamer.html
+++ b/examples/streamer.html
@@ -243,7 +243,7 @@
                     const host = options.host;
                     this.host = new NetAddress(host || location.host, 4433);
                     this.streamName = options.stream;
-                    this.accessToken = options.token;
+                    this.accessToken = options.accessToken;
                     this.connectorType = options.whip || (host && host.toLowerCase().startsWith('http')) ? this.connectorTypes[1] : this.connectorTypes[0];
 
                     this.diagnostics = options.diagnostics || options.debug;


### PR DESCRIPTION
For consistency we need to use the word accessToken in the samples, not token