### PR TITLE
feature(watchdog) add watchdog for report monitoring in WebSocket signaling

### DIFF
--- a/src/connectors/WSController.ts
+++ b/src/connectors/WSController.ts
@@ -220,8 +220,7 @@ export class WSController extends SIPConnector implements IController {
                 ? Date.now() - this._reportReceivedTimestamp
                 : REPORT_WATCHDOG_TIMEOUT;
             if (timeout >= REPORT_WATCHDOG_TIMEOUT / 3) {
-                // eslint-disable-next-line no-warning-comments
-                this.onError(`WARNING! No updates received for the last ${(timeout / 1000).toFixed(1)}s`); // TODO replace with warning
+                this.onError(`WARNING! No updates received for the last ${(timeout / 1000).toFixed(1)}s`); // WIP replace with warning
             }
             if (timeout >= REPORT_WATCHDOG_TIMEOUT) {
                 this.close('Signalling connection timeout');

--- a/src/connectors/WSController.ts
+++ b/src/connectors/WSController.ts
@@ -222,7 +222,8 @@ export class WSController extends SIPConnector implements IController {
             if (timeout >= REPORT_WATCHDOG_TIMEOUT / 3) {
                 // eslint-disable-next-line no-warning-comments
                 this.onError(`WARNING! No updates received for the last ${(timeout / 1000).toFixed(1)}s`); // TODO replace with warning
-            } else if (timeout >= REPORT_WATCHDOG_TIMEOUT) {
+            }
+            if (timeout >= REPORT_WATCHDOG_TIMEOUT) {
                 this.close('Signalling connection timeout');
             }
         }, REPORT_WATCHDOG_TIMEOUT / 6);

--- a/src/connectors/WSController.ts
+++ b/src/connectors/WSController.ts
@@ -192,7 +192,7 @@ export class WSController extends SIPConnector implements IController {
                 break;
             }
             case 'on_media_receive': {
-                this._reportReceivedTimestamp = Date.now();
+                this._reportReceivedTimestamp = Util.time();
                 this.onMediaReport(ev);
                 break;
             }
@@ -201,7 +201,7 @@ export class WSController extends SIPConnector implements IController {
                 break;
             }
             case 'on_time': {
-                this._reportReceivedTimestamp = Date.now();
+                this._reportReceivedTimestamp = Util.time();
                 this.onPlaying(ev);
                 break;
             }
@@ -213,11 +213,11 @@ export class WSController extends SIPConnector implements IController {
     }
 
     private _startReportWatchdog() {
-        this._reportReceivedTimestamp = Date.now();
+        this._reportReceivedTimestamp = Util.time();
 
         this._reportWatchdogInterval = setInterval(() => {
             const timeout = this._reportReceivedTimestamp
-                ? Date.now() - this._reportReceivedTimestamp
+                ? Util.time() - this._reportReceivedTimestamp
                 : REPORT_WATCHDOG_TIMEOUT;
             if (timeout >= REPORT_WATCHDOG_TIMEOUT / 3) {
                 this.onError(`WARNING! No updates received for the last ${(timeout / 1000).toFixed(1)}s`); // WIP replace with warning


### PR DESCRIPTION
Add watchdog for report monitoring in WebSocket signaling

This commit introduces a watchdog that periodically checks for received reports over the WebSocket signaling connection. If no reports are received for 30 seconds, the watchdog will close the signaling connection and terminate the WebRTC session to ensure stability and prevent hanging connections.
