### PR TITLE
Provide more build varients, don't bundle by default

### DIFF
--- a/examples/player-with-timed-metadata.html
+++ b/examples/player-with-timed-metadata.html
@@ -21,7 +21,7 @@
         <textarea id="metadata" rows="10" readonly></textarea>
 
         <script type="module">
-            import { Player, utils } from "../dist/webrtc-client.js";
+            import { Player, utils } from "../dist/webrtc-client.bundle.es.js";
 
             const { NetAddress, Util } = utils;
 

--- a/examples/player.html
+++ b/examples/player.html
@@ -121,7 +121,7 @@
         </div>
 
         <script type="module">
-            import { Player, HTTPConnector, WSController, VERSION, utils } from "../dist/webrtc-client.min.js";
+            import { Player, HTTPConnector, WSController, VERSION, utils } from "../dist/webrtc-client.bundle.es.js";
             // development version, includes helpful console warnings
             // import { createApp } from 'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.esm-browser.js';
             // production version, optimized for size and speed

--- a/examples/streamer.html
+++ b/examples/streamer.html
@@ -176,7 +176,7 @@
         <!-- production version, optimized for size and speed -->
         <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
         <script type="module">
-            import { Streamer, StreamerStats, HTTPConnector, WSController, VERSION, utils } from "../dist/webrtc-client.js";
+            import { Streamer, StreamerStats, HTTPConnector, WSController, VERSION, utils } from "../dist/webrtc-client.bundle.es.js";
 
             const { NetAddress, Util, log } = utils;
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "bugs": {
         "url": "https://github.com/ceebluetv/webrtc-client/issues"
     },
-    "main": "dist/webrtc-client.js",
+    "main": "dist/webrtc-client.cjs.js",
+    "module": "dist/webrtc-client.es.js",
+    "browser": "dist/webrtc-client.bundle.js",
     "types": "dist/webrtc-client.d.ts",
     "type": "module",
     "scripts": {
         "build": "rollup -c",
-        "build:es5": "rollup -c --format umd",
         "build:docs": "typedoc index.ts",
         "lint": "eslint . && prettier --check .",
         "eslint": "eslint --fix .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "esModuleInterop": true,
         "strict": true,
         "target": "ES6",
-        "moduleResolution": "Node"
+        "moduleResolution": "Node",
+        "sourceMap": true
     }
 }


### PR DESCRIPTION
**Changelog:**

1. Removed the unused **build:es5**, it couldn't be built anyway due to errors.
2. Added builds for the following module formats:
   - **.es:** ESM module.
   - **.cjs:** CommonJS module.
   - **.bundle:** IIFE bundle that includes all dependencies.
   - **.bundle.es:** ESM bundle with all dependencies bundled.
   - Enabled source maps, for better debugging. 

Additionally, the **package.json** file has been updated to reference the new builds, And updated examples to use .bundle.es.