### PR TITLE
fix(WSStreamData): fix to avoid creating multiple WSStreamData

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -601,7 +601,9 @@ export class Player extends EventEmitter {
                 .warn();
             setTimeout(() => {
                 if (this._streamData === streamData) {
-                    this._newStreamData(params);
+                    // Re-initialize data tracks
+                    // This will generate a reconnection to the server
+                    streamData.tracks = this._dataTracks;
                 } // else has changed! or player is closed!
             }, RECONNECTION_TIMEOUT);
         };


### PR DESCRIPTION
Sometimes it was possible to create multiple WSStreamData instances with the same player, which could lead to duplicate timed metadatas being received.